### PR TITLE
Add pipefails to make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,9 +112,11 @@ tarball: lib$(NAME)-$(VERSION).tar.gz
 
 all: clean release devbuild tarball staticlib sharedlib test
 
+test: SHELL:=/bin/bash
 test:
 	@mkdir -p out/log/
-	@(cd test && $(MAKE) NAME=$(NAME) 2>&1) | tee out/log/test.log
+	@set -o pipefail; \
+	(cd test && $(MAKE) NAME=$(NAME) 2>&1) | tee out/log/test.log
 
 install_so: lib$(NAME).so
 	@if [ $$(id -u) -ne 0 ] && [ $(INSTALLTO) = /usr/local/bin ]; then echo --- YOU MAY WISH TO INSTALL AS ROOT; fi

--- a/test/Makefile
+++ b/test/Makefile
@@ -18,8 +18,9 @@ log/%: $(LOG)/%.log
 
 ### TESTS
 
-$(LOG)/testbin.log: $(BIN)
+$(LOG)/testbin.log: SHELL:=/bin/bash
+$(LOG)/testbin.log: $(BIN) testbin.bash
 	@echo
-	./testbin.bash | tee $@
+	set -o pipefail; ./testbin.bash | tee $@
 	@echo
 

--- a/test/testbin.bash
+++ b/test/testbin.bash
@@ -2,10 +2,10 @@
 
 set -e
 
-[ "$(../bin)" = $'Hello, World!' ]            && echo Test 1 Passed
-[ "$(../bin A)" = $'Hello, A!' ]              && echo Test 2 Passed
-[ "$(../bin B)" = $'Hello, B!' ]              && echo Test 3 Passed
-[ "$(../bin C D)" = $'Hello, C!\nHello, D!' ] && echo Test 4 Passed
-[ "$(../bin -h)" = $'Hello, -h!' ]            && echo Test 5 Passed
-[ "$(../bin World)" = $'Hello, World!' ]      && echo Test 6 Passed
-[ "$(../bin '')" = $'Hello, !' ]              && echo Test 7 Passed
+[ "$(../bin)" = $'Hello, World!' ]            && echo Test 1 Passed || exit 1
+[ "$(../bin A)" = $'Hello, A!' ]              && echo Test 2 Passed || exit 1
+[ "$(../bin B)" = $'Hello, B!' ]              && echo Test 3 Passed || exit 1
+[ "$(../bin C D)" = $'Hello, C!\nHello, D!' ] && echo Test 4 Passed || exit 1
+[ "$(../bin -h)" = $'Hello, -h!' ]            && echo Test 5 Passed || exit 1
+[ "$(../bin World)" = $'Hello, World!' ]      && echo Test 6 Passed || exit 1
+[ "$(../bin '')" = $'Hello, !' ]              && echo Test 7 Passed || exit 1


### PR DESCRIPTION
Add pipefails to make test, so that tests actually stop the build process.
Before, they would simply fail silently due to the "| tee" unless tee also died.
